### PR TITLE
Ensure file transfers advertise file basename

### DIFF
--- a/File_Class_Manager.py
+++ b/File_Class_Manager.py
@@ -74,7 +74,7 @@ class FileTransManager:
         file_id = random.randint(0, 256)
         while file_id == bytearray('f'.encode('utf8'))[0] or file_id in self.transfer_objects.keys():
             file_id = random.randint(0, 256)
-        print(f'Sending {file_name}...')
+        print(f'Sending {os.path.basename(file_name) or file_name}...')
         self.transfer_objects[file_id] = file_classes.FileTransferSender(file_name, file_id, self.interface,
                                                                          destination, self.send_delay, self.packet_len,
                                                                          disable_bar=False)

--- a/file_classes.py
+++ b/file_classes.py
@@ -111,6 +111,7 @@ class FileTransferSender:
     def __init__(self, file_name, file_id: int, interface, destination_id, send_delay=10, packet_len=200,
                  disable_bar=True):
         self.name = file_name
+        self.display_name = os.path.basename(file_name) or file_name
         self.id = file_id  # 0 Reserved for file meta packets
         self.interface = interface
         self.destination_id = destination_id
@@ -138,7 +139,7 @@ class FileTransferSender:
 
     def send_initial(self):
         # Sends initial packet
-        init_str = Packaging_Data.make_initial_req(self.name, len(self.data_dict), self.id)
+        init_str = Packaging_Data.make_initial_req(self.display_name, len(self.data_dict), self.id)
         try:
             self.interface.sendText(init_str, destinationId=self.destination_id)
             self.last_activity = time.time()

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -54,12 +54,14 @@ class FakeInterface:
     def __init__(self, node_id, network):
         self.node_id = node_id
         self.network = network
+        self.sent_texts = []
 
     def sendData(self, data, destinationId, portNum=None, wantAck=False):
         del portNum, wantAck  # Unused in tests
         self.network.send_data(self.node_id, destinationId, data)
 
     def sendText(self, text, destinationId):
+        self.sent_texts.append((destinationId, text))
         self.network.send_text(self.node_id, destinationId, text)
 
 
@@ -188,6 +190,27 @@ def test_transfer_completes_on_open_channel(tmp_path):
     assert sender.finished
     assert receiver_node.receiver is not None and receiver_node.receiver.finished
     assert source_path.read_bytes() == payload
+
+
+def test_initial_request_uses_basename(tmp_path):
+    _payload, fake_time, network, sender_iface, _receiver_node, source_path, send_delay = build_transfer(
+        tmp_path, packet_len=64, send_delay=0.1
+    )
+
+    with patch("file_classes.time", fake_time), patch("file_classes.tqdm.tqdm", DummyProgressBar):
+        file_classes.FileTransferSender(
+            str(source_path),
+            7,
+            sender_iface,
+            "receiver",
+            send_delay=send_delay,
+            packet_len=64,
+            disable_bar=True,
+        )
+
+    assert sender_iface.sent_texts, "no initial request was sent"
+    _dest, message = sender_iface.sent_texts[0]
+    assert f"!fcom,file:{source_path.name}," in message
 
 
 def test_transfer_handles_out_of_order_delivery(tmp_path):


### PR DESCRIPTION
## Summary
- stop including absolute paths in the initial transfer request so receivers only see the filename
- show the shortened filename in sender logging and cover the behaviour with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da5c7d1ba883248c56565466e27e1e