### PR TITLE
Throttle file sender rate and improve text logging

### DIFF
--- a/Receiver/receiver.py
+++ b/Receiver/receiver.py
@@ -53,8 +53,7 @@ def main(interface):
             if Text_Queue:  # handle text data
                 name, packet = Text_Queue.pop(0)
                 text = packet['decoded']['text']
-                print(f'Text Received: {text}')
-                LOGGER.debug('Received text from %s: %s', name, text)
+                LOGGER.info('Text received from %s: %s', name, text)
                 if text[0:5] == '!fcom':
                     LOGGER.info('Received transfer request %s from %s', text, packet['fromId'])
                     manager.new_req_packet(text, packet['fromId'], timeout=time_out)

--- a/Sender/sender.py
+++ b/Sender/sender.py
@@ -96,8 +96,7 @@ def main(interface):
             if Text_Queue:  # handle text data
                 name, packet = Text_Queue.pop(0)
                 text = packet['decoded']['text']
-                print(f'Text Received: {text}')
-                LOGGER.debug('Received text from %s: %s', name, text)
+                LOGGER.info('Text received from %s: %s', name, text)
 
             if len(manager.transfer_objects) == 0:
                 looping = False

--- a/file_classes.py
+++ b/file_classes.py
@@ -146,7 +146,10 @@ class FileTransferSender:
         self.retry_timeout = max(self.delay * 2, 3)
         self.window_size = max(1, min(5, len(self.data_dict)))
         self.packet_num = len(self.data_dict)
-        self.last_send = time.time()
+        # Track when the last packet was transmitted so we can throttle the
+        # send rate. Initialise to zero so the very first packet is allowed to
+        # go out immediately.
+        self.last_send = 0
         self.last_activity = time.time()
         # Modes- 0: Waiting for initial ack, 2: Sending Data, 3: Waiting for completion confirmation
         self.mode = 0
@@ -259,6 +262,16 @@ class FileTransferSender:
 
     def _fill_window(self):
         while self.to_send and len(self.pending_packets) < self.window_size and not self.kill:
+            now = time.time()
+            if self.last_send and now - self.last_send < self.delay:
+                remaining = self.delay - (now - self.last_send)
+                LOGGER.debug(
+                    'Delaying send of next packet for %s (%s); %.2fs remaining in rate limit',
+                    self.name,
+                    self.id,
+                    max(0, remaining),
+                )
+                break
             packet_index = self.to_send.pop(0)
             if packet_index in self.acknowledged_packets:
                 continue


### PR DESCRIPTION
## Summary
- log incoming text messages on both sender and receiver so chat traffic is captured in logs
- throttle sender packet dispatch using the configured delay to avoid flooding the receiver
- initialize sender timing state to allow the first packet to depart immediately while respecting rate limits afterwards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da64a50b508324b8308580df1cba77