### PR TITLE
Enable radio acknowledgements for file transfers

### DIFF
--- a/file_classes.py
+++ b/file_classes.py
@@ -120,8 +120,12 @@ class FileTransferReceiver:
     def _send_control_packet(self, data, description='control'):
         """Sends data over interface to destination"""
         try:
-            self.interface.sendData(bytes(data), destinationId=self.sending_id,
-                                    portNum=portnums_pb2.IP_TUNNEL_APP, wantAck=False)
+            self.interface.sendData(
+                bytes(data),
+                destinationId=self.sending_id,
+                portNum=portnums_pb2.IP_TUNNEL_APP,
+                wantAck=True,
+            )
             self.last_control_sent = time.time()
             LOGGER.debug('Sent %s packet for %s (%s)', description, self.name, self.id)
         except Exception as exc:
@@ -168,7 +172,11 @@ class FileTransferSender:
         # Sends initial packet
         init_str = Packaging_Data.make_initial_req(self.display_name, len(self.data_dict), self.id)
         try:
-            self.interface.sendText(init_str, destinationId=self.destination_id)
+            self.interface.sendText(
+                init_str,
+                destinationId=self.destination_id,
+                wantAck=True,
+            )
             self.last_activity = time.time()
             LOGGER.info('Sent initial request for %s (%s packets) to %s', self.name, self.packet_num, self.destination_id)
         except Exception as exc:
@@ -292,8 +300,12 @@ class FileTransferSender:
             LOGGER.error('Attempted to send missing packet #%s for %s', packet_index, self.name)
             return
         try:
-            self.interface.sendData(bytes(data), portNum=portnums_pb2.IP_TUNNEL_APP,
-                                    destinationId=self.destination_id, wantAck=False)
+            self.interface.sendData(
+                bytes(data),
+                portNum=portnums_pb2.IP_TUNNEL_APP,
+                destinationId=self.destination_id,
+                wantAck=True,
+            )
             sent_time = time.time()
             self.pending_packets[packet_index] = sent_time
             self.last_send = sent_time
@@ -308,8 +320,12 @@ class FileTransferSender:
     def _send_finish(self):
         finish_packet = Packaging_Data.make_status_packet(self.id, 2)
         try:
-            self.interface.sendData(bytes(finish_packet), portNum=portnums_pb2.IP_TUNNEL_APP,
-                                    destinationId=self.destination_id, wantAck=False)
+            self.interface.sendData(
+                bytes(finish_packet),
+                portNum=portnums_pb2.IP_TUNNEL_APP,
+                destinationId=self.destination_id,
+                wantAck=True,
+            )
             self.finish_sent = True
             self.last_send = time.time()
             self.last_activity = self.last_send

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -60,7 +60,7 @@ class FakeInterface:
         del portNum, wantAck  # Unused in tests
         self.network.send_data(self.node_id, destinationId, data)
 
-    def sendText(self, text, destinationId):
+    def sendText(self, text, destinationId, wantAck=False):
         self.sent_texts.append((destinationId, text))
         self.network.send_text(self.node_id, destinationId, text)
 


### PR DESCRIPTION
## Summary
- request hardware-level acknowledgements for all file transfer control, data, and completion packets
- ensure initial transfer requests also request an acknowledgement to reduce repeated prompts
- update the fake interface used in tests to accept the optional acknowledgement flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da703f86b48324bbc5d5b00c1707ab