### PR TITLE
Make auto-accept a flag in receiver CLI

### DIFF
--- a/Receiver/receiver.py
+++ b/Receiver/receiver.py
@@ -83,7 +83,12 @@ if __name__ == '__main__':
         prog='Meshtastic File Receiver',
         description='Reveives a file or directory to another node running the receiver program',)
     parser.add_argument('-t', '--time_out', default=300, help='Time between packets before giving up')
-    parser.add_argument('-a', '--auto_accept', default=False, help='Automatically accepts file transfers')
+    parser.add_argument(
+        '-a',
+        '--auto_accept',
+        action='store_true',
+        help='Automatically accepts file transfers',
+    )
     ports = findPorts(True)
     print(f'Number of Radios: {len(ports)}')
     interface = None


### PR DESCRIPTION
## Summary
- update the receiver CLI so the auto-accept option is a boolean flag
- keep the existing logging while ensuring users can simply pass -a without a value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7801655c83249ce8a743e01110f2