### PR TITLE
Handle duplicate and concurrent file transfer sessions

### DIFF
--- a/File_Class_Manager.py
+++ b/File_Class_Manager.py
@@ -9,7 +9,7 @@ LOGGER = logging.getLogger(__name__)
 
 class FileTransManager:
     def __init__(self, interface, send_delay=7, packet_len=200, destination=None, auto_restart=False):
-        self.transfer_objects = {}  # id: file_sender/file_receiver
+        self.transfer_objects = {}  # (direction, peer, id): file_sender/file_receiver
         self.interface = interface
         self.send_delay = send_delay
         self.packet_len = packet_len
@@ -18,13 +18,18 @@ class FileTransManager:
         self.done = False
         self.restart = auto_restart
 
+    def _make_key(self, direction: str, peer_id, file_id: int):
+        """Generate a dictionary key for a transfer direction/peer combination."""
+        return direction, peer_id or '', int(file_id)
+
     def update_all(self):
         """Calls update method on each object"""
         deleted_keys = []
-        for key in self.transfer_objects.keys():
-            LOGGER.debug('Updating transfer object %s (%s)', key, type(self.transfer_objects[key]).__name__)
-            self.transfer_objects[key].update()
-            if self.transfer_objects[key].kill:
+        for key in list(self.transfer_objects.keys()):
+            transfer = self.transfer_objects[key]
+            LOGGER.debug('Updating transfer object %s (%s)', key, type(transfer).__name__)
+            transfer.update()
+            if transfer.kill:
                 deleted_keys.append(key)
 
         for key in deleted_keys:
@@ -50,29 +55,51 @@ class FileTransManager:
                 self.done = True
                 LOGGER.debug('No active transfers remaining')
 
-    def new_data_packet(self, packet):
-        """Called to process new data packet"""
-        if packet[0] == bytearray('f'.encode('utf8'))[0]:
+    def new_data_packet(self, packet, from_id=None):
+        """Called to process new data or control packet"""
+        if not packet:
+            LOGGER.warning('Received empty packet from %s, ignoring', from_id)
+            return
+
+        control_prefix = bytearray('f'.encode('utf8'))[0]
+        if packet[0] == control_prefix:
             f_id = packet[4]
-            transfer = self.transfer_objects.get(f_id)
+            key = self._make_key('recv', from_id, f_id)
+            transfer = self.transfer_objects.get(key)
             if transfer:
-                LOGGER.debug('Routing control packet type %s to transfer %s', packet[5], f_id)
+                LOGGER.debug('Routing control packet type %s from %s to receiver %s', packet[5], from_id, key)
                 transfer.manage_com_packet(packet)
-            else:
-                print(f'Received control packet for unknown transfer id {f_id}, ignoring')
-                LOGGER.warning('Control packet for unknown transfer id %s: %s', f_id, packet)
-        elif packet[0] in self.transfer_objects.keys():
-            # print(f'file packet received for {int(packet[0])}: {packet}')
-            LOGGER.debug('Routing data packet #%s to transfer %s', packet[1], packet[0])
-            self.transfer_objects[packet[0]].add_packet(packet)
+                return
+            key = self._make_key('send', from_id, f_id)
+            transfer = self.transfer_objects.get(key)
+            if transfer:
+                LOGGER.debug('Routing control packet type %s from %s to sender %s', packet[5], from_id, key)
+                transfer.manage_com_packet(packet)
+                return
+            print(f'Received control packet for unknown transfer id {f_id}, ignoring')
+            LOGGER.warning('Control packet for unknown transfer id %s from %s: %s', f_id, from_id, packet)
+            return
+
+        key = self._make_key('recv', from_id, packet[0])
+        transfer = self.transfer_objects.get(key)
+        if transfer:
+            LOGGER.debug('Routing data packet #%s from %s to receiver %s', packet[1], from_id, key)
+            transfer.add_packet(packet)
         else:
             print(f'something went Wrong: {packet}')
-            LOGGER.error('Received unrecognized packet prefix %s: %s', packet[0], packet)
+            LOGGER.error('Received data packet for unknown transfer id %s from %s: %s', packet[0], from_id, packet)
 
     def new_req_packet(self, initial_req, sending_id, timeout=100):
         """Called to make new file_receiving packet based on a request packet"""
         file_name, f_id, num = decode_initial_req(initial_req)
         LOGGER.info('New transfer request %s id=%s packets=%s from %s', file_name, f_id, num, sending_id)
+        key = self._make_key('recv', sending_id, f_id)
+        existing = self.transfer_objects.get(key)
+        if existing:
+            LOGGER.info('Duplicate transfer request for %s (%s) from %s; resending acknowledgement', file_name, f_id, sending_id)
+            existing.resend_initial_ack()
+            return
+
         if self.restart:
             print(f'Automatically Accepted {file_name} with a size of {round(num*self.packet_len / 1000, 2)}kb.')
             LOGGER.debug('Auto-accept enabled, proceeding with %s', file_name)
@@ -81,20 +108,34 @@ class FileTransManager:
         else:
             LOGGER.info('Transfer request %s was declined', f_id)
             return
-        self.transfer_objects[f_id] = file_classes.FileTransferReceiver(file_name, f_id, num, self.interface,
-                                                                        sending_id, timeout=timeout)
-        LOGGER.debug('Transfer receiver created for %s (%s)', file_name, f_id)
+        self.transfer_objects[key] = file_classes.FileTransferReceiver(
+            file_name,
+            f_id,
+            num,
+            self.interface,
+            sending_id,
+            timeout=timeout,
+        )
+        LOGGER.debug('Transfer receiver created for %s (%s) from %s', file_name, f_id, sending_id)
 
     def send_new_file(self, file_name, destination):
         """Called to make new file sending object"""
-        file_id = random.randint(0, 256)
-        while file_id == bytearray('f'.encode('utf8'))[0] or file_id in self.transfer_objects.keys():
-            file_id = random.randint(0, 256)
+        file_id = random.randint(0, 255)
+        key = self._make_key('send', destination, file_id)
+        while file_id == bytearray('f'.encode('utf8'))[0] or key in self.transfer_objects:
+            file_id = random.randint(0, 255)
+            key = self._make_key('send', destination, file_id)
         print(f'Sending {os.path.basename(file_name) or file_name}...')
         LOGGER.info('Preparing new transfer %s (%s) to %s', file_name, file_id, destination)
-        self.transfer_objects[file_id] = file_classes.FileTransferSender(file_name, file_id, self.interface,
-                                                                         destination, self.send_delay, self.packet_len,
-                                                                         disable_bar=False)
+        self.transfer_objects[key] = file_classes.FileTransferSender(
+            file_name,
+            file_id,
+            self.interface,
+            destination,
+            self.send_delay,
+            self.packet_len,
+            disable_bar=False,
+        )
 
     def send_new_files(self, file_names: list, destination=None):
         """Called to make new file sending object"""

--- a/Receiver/receiver.py
+++ b/Receiver/receiver.py
@@ -48,8 +48,14 @@ def main(interface):
             if Queue:  # Handle binary data
                 name, packet = Queue.pop(0)
                 payload = packet['decoded']['payload']
-                LOGGER.debug('Processing binary packet from %s (%s bytes)', name, len(payload) if payload else 0)
-                manager.new_data_packet(bytearray(payload))
+                from_id = packet.get('fromId')
+                LOGGER.debug(
+                    'Processing binary packet from %s (%s bytes) sender=%s',
+                    name,
+                    len(payload) if payload else 0,
+                    from_id,
+                )
+                manager.new_data_packet(bytearray(payload), from_id=from_id)
             if Text_Queue:  # handle text data
                 name, packet = Text_Queue.pop(0)
                 text = packet['decoded']['text']

--- a/Sender/sender.py
+++ b/Sender/sender.py
@@ -91,8 +91,14 @@ def main(interface):
             if Queue:  # Handle binary data
                 name, packet = Queue.pop(0)
                 payload = packet['decoded']['payload']
-                LOGGER.debug('Processing %s control/data packet from %s', len(payload) if payload else 0, name)
-                manager.new_data_packet(bytearray(payload))
+                from_id = packet.get('fromId')
+                LOGGER.debug(
+                    'Processing %s control/data packet from %s (%s)',
+                    len(payload) if payload else 0,
+                    name,
+                    from_id,
+                )
+                manager.new_data_packet(bytearray(payload), from_id=from_id)
             if Text_Queue:  # handle text data
                 name, packet = Text_Queue.pop(0)
                 text = packet['decoded']['text']

--- a/file_classes.py
+++ b/file_classes.py
@@ -117,6 +117,10 @@ class FileTransferReceiver:
         initial_ack = Packaging_Data.make_status_packet(self.id, 1)
         self._send_control_packet(initial_ack, description='initial ack')
 
+    def resend_initial_ack(self):
+        LOGGER.info('Resending initial acknowledgement for %s (%s)', self.name, self.id)
+        self._send_initial_ack()
+
     def _send_control_packet(self, data, description='control'):
         """Sends data over interface to destination"""
         try:


### PR DESCRIPTION
## Summary
- key transfers by direction and peer so multiple sessions with identical ids no longer collide
- reuse existing receivers for duplicate requests and resend the initial acknowledgement instead of spawning new transfers
- propagate packet sender information through the CLI tools so data and control packets are routed to the right session

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7ad7ccd08324ae7ce374f605bec3