### PR TITLE
Use core text port for file transfer payloads

### DIFF
--- a/Receiver/receiver.py
+++ b/Receiver/receiver.py
@@ -31,6 +31,24 @@ Text_Queue = []
 Queue = []
 
 
+CORE_PORTNUMS = {
+    'TEXT_MESSAGE_APP',
+    'TEXT_MESSAGE_COMPRESSED_APP',
+    'POSITION_APP',
+    'NODEINFO_APP',
+    'ROUTING_APP',
+    'TELEMETRY_APP',
+    'ADMIN_APP',
+    'ALERT_APP',
+    'KEY_VERIFICATION_APP',
+    'WAYPOINT_APP',
+    'STORE_FORWARD_APP',
+    'TRACEROUTE_APP',
+}
+
+TRANSFER_PORT_NAME = 'TEXT_MESSAGE_APP'
+
+
 def main(interface):
     args = parser.parse_args()
     # Args to be used
@@ -77,9 +95,11 @@ def on_receive(packet, interface): # called when a packet arrives
         packet.get('fromId'),
         interface.getShortName(),
     )
-    if packet['decoded']['portnum'] == 'IP_TUNNEL_APP':
+    decoded = packet.get('decoded', {})
+    portnum = decoded.get('portnum')
+    if portnum == TRANSFER_PORT_NAME and 'payload' in decoded:
         Queue.append((interface.getShortName(), packet))
-    elif packet['decoded']['portnum'] == 'TEXT_MESSAGE_APP':
+    elif portnum in CORE_PORTNUMS and 'text' in decoded:
         Text_Queue.append((interface.getShortName(), packet))
 
 

--- a/Sender/sender.py
+++ b/Sender/sender.py
@@ -31,6 +31,24 @@ Text_Queue = []
 Queue = []
 
 
+CORE_PORTNUMS = {
+    'TEXT_MESSAGE_APP',
+    'TEXT_MESSAGE_COMPRESSED_APP',
+    'POSITION_APP',
+    'NODEINFO_APP',
+    'ROUTING_APP',
+    'TELEMETRY_APP',
+    'ADMIN_APP',
+    'ALERT_APP',
+    'KEY_VERIFICATION_APP',
+    'WAYPOINT_APP',
+    'STORE_FORWARD_APP',
+    'TRACEROUTE_APP',
+}
+
+TRANSFER_PORT_NAME = 'TEXT_MESSAGE_APP'
+
+
 def main(interface):
     args = parser.parse_args()
     # Args to be used
@@ -120,9 +138,11 @@ def on_receive(packet, interface): # called when a packet arrives
         packet.get('fromId'),
         interface.getShortName(),
     )
-    if packet['decoded']['portnum'] == 'IP_TUNNEL_APP':
+    decoded = packet.get('decoded', {})
+    portnum = decoded.get('portnum')
+    if portnum == TRANSFER_PORT_NAME and 'payload' in decoded:
         Queue.append((interface.getShortName(), packet))
-    elif packet['decoded']['portnum'] == 'TEXT_MESSAGE_APP':
+    elif portnum in CORE_PORTNUMS and 'text' in decoded:
         Text_Queue.append((interface.getShortName(), packet))
 
 

--- a/file_classes.py
+++ b/file_classes.py
@@ -7,6 +7,10 @@ import tqdm
 
 LOGGER = logging.getLogger(__name__)
 
+# File transfer traffic now uses the same core port number as the initial
+# request message so radios treat the packets as standard application data.
+TRANSFER_PORTNUM = portnums_pb2.TEXT_MESSAGE_APP
+
 class FileTransferReceiver:
     """Class used to store and handle incoming file packets and should be created when the first request packet is
     acknowledged. Added to as the packets come in. Checked when the last packet number arrives or when a timeout is
@@ -127,7 +131,7 @@ class FileTransferReceiver:
             self.interface.sendData(
                 bytes(data),
                 destinationId=self.sending_id,
-                portNum=portnums_pb2.IP_TUNNEL_APP,
+                portNum=TRANSFER_PORTNUM,
                 wantAck=True,
             )
             self.last_control_sent = time.time()
@@ -306,7 +310,7 @@ class FileTransferSender:
         try:
             self.interface.sendData(
                 bytes(data),
-                portNum=portnums_pb2.IP_TUNNEL_APP,
+                portNum=TRANSFER_PORTNUM,
                 destinationId=self.destination_id,
                 wantAck=True,
             )
@@ -326,7 +330,7 @@ class FileTransferSender:
         try:
             self.interface.sendData(
                 bytes(finish_packet),
-                portNum=portnums_pb2.IP_TUNNEL_APP,
+                portNum=TRANSFER_PORTNUM,
                 destinationId=self.destination_id,
                 wantAck=True,
             )

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -10,7 +10,18 @@ from unittest.mock import patch
 if "meshtastic" not in sys.modules:
     meshtastic_module = types.ModuleType("meshtastic")
     portnums_module = types.ModuleType("meshtastic.portnums_pb2")
-    portnums_module.IP_TUNNEL_APP = 1
+    portnums_module.TEXT_MESSAGE_APP = 1
+    portnums_module.TEXT_MESSAGE_COMPRESSED_APP = 2
+    portnums_module.POSITION_APP = 3
+    portnums_module.NODEINFO_APP = 4
+    portnums_module.ROUTING_APP = 5
+    portnums_module.TELEMETRY_APP = 6
+    portnums_module.ADMIN_APP = 7
+    portnums_module.ALERT_APP = 8
+    portnums_module.KEY_VERIFICATION_APP = 9
+    portnums_module.WAYPOINT_APP = 10
+    portnums_module.STORE_FORWARD_APP = 11
+    portnums_module.TRACEROUTE_APP = 12
     meshtastic_module.portnums_pb2 = portnums_module
     sys.modules["meshtastic"] = meshtastic_module
     sys.modules["meshtastic.portnums_pb2"] = portnums_module
@@ -23,6 +34,7 @@ if TEST_ROOT not in sys.path:
 
 import Packaging_Data
 import file_classes
+from meshtastic import portnums_pb2
 
 
 class FakeTime:
@@ -55,9 +67,10 @@ class FakeInterface:
         self.node_id = node_id
         self.network = network
         self.sent_texts = []
+        self.sent_data = []
 
     def sendData(self, data, destinationId, portNum=None, wantAck=False):
-        del portNum, wantAck  # Unused in tests
+        self.sent_data.append((destinationId, data, portNum, wantAck))
         self.network.send_data(self.node_id, destinationId, data)
 
     def sendText(self, text, destinationId, wantAck=False):
@@ -190,6 +203,9 @@ def test_transfer_completes_on_open_channel(tmp_path):
     assert sender.finished
     assert receiver_node.receiver is not None and receiver_node.receiver.finished
     assert source_path.read_bytes() == payload
+    assert all(
+        portNum == portnums_pb2.TEXT_MESSAGE_APP for _dest, _data, portNum, _wantAck in sender_iface.sent_data
+    )
 
 
 def test_initial_request_uses_basename(tmp_path):


### PR DESCRIPTION
## Summary
- route file transfer control and data packets through the core TEXT_MESSAGE_APP port number
- update sender and receiver listeners to separate binary payloads from other core traffic
- extend the test harness with core port constants and assert transfers use the text port

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7e725eec8324ad0328e007eb3a14