### PR TITLE
Handle embedded initial requests in binary payloads

### DIFF
--- a/File_Class_Manager.py
+++ b/File_Class_Manager.py
@@ -55,10 +55,27 @@ class FileTransManager:
                 self.done = True
                 LOGGER.debug('No active transfers remaining')
 
+    def _is_embedded_initial_request(self, packet: bytearray) -> bool:
+        """Return True if the payload contains an inline initial request."""
+        return len(packet) > 6 and packet[0] == ord('!') and packet[1:6] == b'fcom,'
+
     def new_data_packet(self, packet, from_id=None):
         """Called to process new data or control packet"""
         if not packet:
             LOGGER.warning('Received empty packet from %s, ignoring', from_id)
+            return
+
+        if self._is_embedded_initial_request(packet):
+            try:
+                request = packet.decode('utf8')
+            except UnicodeDecodeError:
+                request = packet.decode('utf8', errors='ignore')
+            LOGGER.info(
+                'Detected embedded initial request from %s: %s',
+                from_id,
+                request,
+            )
+            self.new_req_packet(request, from_id)
             return
 
         control_prefix = bytearray('f'.encode('utf8'))[0]
@@ -91,7 +108,16 @@ class FileTransManager:
 
     def new_req_packet(self, initial_req, sending_id, timeout=100):
         """Called to make new file_receiving packet based on a request packet"""
-        file_name, f_id, num = decode_initial_req(initial_req)
+        try:
+            file_name, f_id, num = decode_initial_req(initial_req)
+        except (ValueError, KeyError) as exc:
+            LOGGER.warning(
+                'Failed to decode initial request from %s: %s (%s)',
+                sending_id,
+                initial_req,
+                exc,
+            )
+            return
         LOGGER.info('New transfer request %s id=%s packets=%s from %s', file_name, f_id, num, sending_id)
         key = self._make_key('recv', sending_id, f_id)
         existing = self.transfer_objects.get(key)

--- a/Packaging_Data.py
+++ b/Packaging_Data.py
@@ -41,9 +41,20 @@ def send_packets_dict_to_file(byte_dict: dict, file_name='Sending/packets.txt'):
 def make_initial_req(file_name: str, packet_num, id):
     return f'!fcom,file:{file_name},packets:{packet_num},id:{id}'
 
-def decode_initial_req(string: str):
-    """Returns file_name, packet_num, and file id of request
+def decode_initial_req(message):
+    """Returns file_name, packet_num, and file id of request.
+
+    The initial request can arrive either as a text string or as raw bytes
+    depending on how the radio firmware delivers the packet.  Normalise the
+    input here so the rest of the code can treat both forms identically.
+
     ex:!fcom,file:rImages/image-file-compressed.webp,packets:21,id:194"""
+    if isinstance(message, (bytes, bytearray)):
+        string = message.decode('utf8', errors='ignore')
+    else:
+        string = str(message)
+
+    string = string.strip()
     fields = string.split(',')
     ret = {}
     for field in fields[1:]:

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -34,6 +34,7 @@ if TEST_ROOT not in sys.path:
 
 import Packaging_Data
 import file_classes
+from File_Class_Manager import FileTransManager
 from meshtastic import portnums_pb2
 
 
@@ -76,6 +77,18 @@ class FakeInterface:
     def sendText(self, text, destinationId, wantAck=False):
         self.sent_texts.append((destinationId, text))
         self.network.send_text(self.node_id, destinationId, text)
+
+
+class DummyInterface:
+    def __init__(self):
+        self.sent_data = []
+        self.sent_text = []
+
+    def sendData(self, data, destinationId=None, portNum=None, wantAck=False):
+        self.sent_data.append((destinationId, bytes(data), portNum, wantAck))
+
+    def sendText(self, text, destinationId=None, wantAck=False):
+        self.sent_text.append((destinationId, text, wantAck))
 
 
 class FakeNetwork:
@@ -321,4 +334,16 @@ def test_transfer_completes_with_link_delay(tmp_path):
     assert sender.finished
     assert receiver_node.receiver is not None and receiver_node.receiver.finished
     assert source_path.read_bytes() == payload
+
+
+def test_manager_handles_initial_request_in_payload():
+    interface = DummyInterface()
+    manager = FileTransManager(interface, auto_restart=True)
+    request = Packaging_Data.make_initial_req('sample.bin', 4, 55).encode('utf8')
+
+    with patch('file_classes.tqdm.tqdm', DummyProgressBar):
+        manager.new_data_packet(bytearray(request), from_id='peer')
+
+    key = manager._make_key('recv', 'peer', 55)
+    assert key in manager.transfer_objects
 


### PR DESCRIPTION
## Summary
- detect and route initial requests that now arrive as binary payloads before treating them as data packets
- normalise decoding of request strings and guard against malformed inputs
- cover the regression with a dedicated unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da80bdba4483248334ea5aa3c2f03c