### PR TITLE
Fix receiver message routing and add tests

### DIFF
--- a/Receiver/receiver.py
+++ b/Receiver/receiver.py
@@ -78,7 +78,7 @@ def main(interface):
                 name, packet = Text_Queue.pop(0)
                 text = packet['decoded']['text']
                 LOGGER.info('Text received from %s: %s', name, text)
-                if text[0:5] == '!fcom':
+                if text.startswith('!fcom'):
                     LOGGER.info('Received transfer request %s from %s', text, packet['fromId'])
                     manager.new_req_packet(text, packet['fromId'], timeout=time_out)
         interface.close()
@@ -97,10 +97,11 @@ def on_receive(packet, interface): # called when a packet arrives
     )
     decoded = packet.get('decoded', {})
     portnum = decoded.get('portnum')
-    if portnum == TRANSFER_PORT_NAME and 'payload' in decoded:
-        Queue.append((interface.getShortName(), packet))
-    elif portnum in CORE_PORTNUMS and 'text' in decoded:
+    text = decoded.get('text') if portnum in CORE_PORTNUMS else None
+    if portnum in CORE_PORTNUMS and text is not None:
         Text_Queue.append((interface.getShortName(), packet))
+    elif portnum == TRANSFER_PORT_NAME and 'payload' in decoded:
+        Queue.append((interface.getShortName(), packet))
 
 
 if __name__ == '__main__':

--- a/tests/test_receiver_routing.py
+++ b/tests/test_receiver_routing.py
@@ -1,0 +1,84 @@
+import sys
+import types
+
+
+if "meshtastic" not in sys.modules:
+    meshtastic_module = types.ModuleType("meshtastic")
+    sys.modules["meshtastic"] = meshtastic_module
+else:
+    meshtastic_module = sys.modules["meshtastic"]
+
+
+serial_module = sys.modules.get("meshtastic.serial_interface")
+if serial_module is None:
+    serial_module = types.ModuleType("meshtastic.serial_interface")
+
+    class SerialInterface:  # pragma: no cover - stub for import side effects
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("SerialInterface stub should not be instantiated in tests")
+
+    serial_module.SerialInterface = SerialInterface
+    sys.modules["meshtastic.serial_interface"] = serial_module
+
+
+util_module = sys.modules.get("meshtastic.util")
+if util_module is None:
+    util_module = types.ModuleType("meshtastic.util")
+
+    def findPorts(_=None):  # pragma: no cover - stub for import side effects
+        return []
+
+    util_module.findPorts = findPorts
+    sys.modules["meshtastic.util"] = util_module
+
+
+from Receiver import receiver
+
+
+class DummyInterface:
+    def __init__(self, name='radio'):
+        self._name = name
+
+    def getShortName(self):
+        return self._name
+
+
+def _reset_queues():
+    receiver.Queue.clear()
+    receiver.Text_Queue.clear()
+
+
+def test_on_receive_routes_text_messages():
+    _reset_queues()
+    packet = {
+        'decoded': {
+            'portnum': receiver.TRANSFER_PORT_NAME,
+            'text': 'hello world',
+            'payload': bytearray(b'hello world'),
+        },
+        'fromId': '!abcd',
+    }
+    iface = DummyInterface()
+
+    receiver.on_receive(packet, iface)
+
+    assert receiver.Queue == []
+    assert receiver.Text_Queue == [(iface.getShortName(), packet)]
+
+
+def test_on_receive_routes_binary_payloads():
+    _reset_queues()
+    binary_packet = {
+        'decoded': {
+            'portnum': receiver.TRANSFER_PORT_NAME,
+            'payload': bytearray(b'\x01\x02\x03'),
+        },
+        'fromId': '!peer',
+    }
+    iface = DummyInterface('peer_radio')
+
+    receiver.on_receive(binary_packet, iface)
+
+    assert receiver.Text_Queue == []
+    assert receiver.Queue == [(iface.getShortName(), binary_packet)]
+


### PR DESCRIPTION
## Summary
- ensure the receiver treats core text messages separately from binary payloads
- guard file transfer request detection against short messages
- add unit tests covering receiver routing logic for text and binary packets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da83371dec8324b6a9df726638d1f3