### PR TITLE
fix: adapt retry timeout handling for slow acknowledgements

### DIFF
--- a/file_classes.py
+++ b/file_classes.py
@@ -4,7 +4,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Dict, Iterable, List, MutableMapping, Sequence, Set
+from typing import Dict, Iterable, List, MutableMapping, Optional, Sequence, Set
 
 import tqdm
 from meshtastic import portnums_pb2
@@ -203,6 +203,10 @@ class FileTransferSender:
         self.finish_sent = False
         self.disable_bar = disable_bar
         self.progress_bar = tqdm.tqdm(total=self.packet_num, unit="packet", disable=self.disable_bar)
+        self._min_retry_timeout = max(self.delay * 2, 3)
+        self._max_retry_timeout = 300.0
+        self.retry_timeout = self._min_retry_timeout
+        self._smoothed_rtt: Optional[float] = None
         self.send_initial()
 
     def send_initial(self) -> None:
@@ -291,11 +295,15 @@ class FileTransferSender:
             self.kill = True
         elif packet_type == 5:
             acknowledged = list(packet[6:])
+            now = time.time()
             for num in acknowledged:
-                self.pending_packets.pop(num, None)
+                sent_time = self.pending_packets.pop(num, None)
                 if num not in self.acknowledged_packets and num < self.packet_num:
                     self.acknowledged_packets.add(num)
                     self.progress_bar.update(1)
+                if sent_time is not None:
+                    rtt = max(0.0, now - sent_time)
+                    self._update_retry_timeout(rtt)
             LOGGER.debug("Acknowledged packets for %s: %s", self.name, acknowledged)
             if self.mode == 0:
                 self.mode = 2
@@ -320,8 +328,10 @@ class FileTransferSender:
 
     def _retry_pending(self, now: float) -> None:
         for packet_index, timestamp in list(self.pending_packets.items()):
-            if now - timestamp > self.retry_timeout:
+            elapsed = now - timestamp
+            if elapsed > self.retry_timeout:
                 self.pending_packets.pop(packet_index, None)
+                self._backoff_retry_timeout(elapsed)
                 if packet_index not in self.to_send:
                     self.to_send.append(packet_index)
                 LOGGER.warning("Packet #%s for %s timed out; rescheduling", packet_index, self.name)
@@ -367,3 +377,40 @@ class FileTransferSender:
             print(f"Failed to send completion notice for {self.name}: {exc}")
             LOGGER.exception("Failed to send completion notice for %s (%s): %s", self.name, self.id, exc)
             self.finish_sent = False
+
+    def _backoff_retry_timeout(self, elapsed: float) -> None:
+        """Increase ``retry_timeout`` to better match the observed network delay."""
+
+        proposed = max(self.retry_timeout * 1.5, elapsed * 2, self._min_retry_timeout)
+        if proposed > self.retry_timeout:
+            self.retry_timeout = min(proposed, self._max_retry_timeout)
+            LOGGER.debug(
+                "Retry timeout for %s increased to %.2fs after %.2fs elapsed",
+                self.name,
+                self.retry_timeout,
+                elapsed,
+            )
+
+    def _update_retry_timeout(self, observed_rtt: float) -> None:
+        """Adapt ``retry_timeout`` based on an ``observed_rtt`` sample."""
+
+        if observed_rtt <= 0:
+            return
+        if self._smoothed_rtt is None:
+            self._smoothed_rtt = observed_rtt
+        else:
+            alpha = 0.2
+            self._smoothed_rtt = (1 - alpha) * self._smoothed_rtt + alpha * observed_rtt
+
+        target = max(self._min_retry_timeout, self._smoothed_rtt * 2.5, observed_rtt * 2.5)
+        capped = min(target, self._max_retry_timeout)
+        if capped < self.retry_timeout:
+            self.retry_timeout = max(capped, self._min_retry_timeout)
+        else:
+            self.retry_timeout = capped
+        LOGGER.debug(
+            "Retry timeout for %s adjusted to %.2fs based on RTT %.2fs",
+            self.name,
+            self.retry_timeout,
+            observed_rtt,
+        )

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -336,6 +336,44 @@ def test_transfer_completes_with_link_delay(tmp_path):
     assert source_path.read_bytes() == payload
 
 
+def test_sender_expands_retry_timeout_for_slow_ack(tmp_path):
+    def slow_ack_hook(src, dest, data):
+        if src == "sender" and dest == "receiver" and not data.startswith(b"fcom"):
+            return {"delay": 0.5}
+        if src == "receiver" and dest == "sender" and data.startswith(b"fcom"):
+            return {"delay": 8.0}
+        return {}
+
+    payload, fake_time, network, sender_iface, receiver_node, source_path, _send_delay = build_transfer(
+        tmp_path, packet_len=60, send_delay=0.5, data_hook=slow_ack_hook
+    )
+
+    with patch("file_classes.time", fake_time), patch("file_classes.tqdm.tqdm", DummyProgressBar):
+        sender = file_classes.FileTransferSender(
+            str(source_path),
+            99,
+            sender_iface,
+            "receiver",
+            send_delay=0.5,
+            packet_len=60,
+            disable_bar=True,
+        )
+        network.register(
+            "sender",
+            on_data=lambda data, _src: sender.manage_com_packet(bytearray(data)),
+        )
+        run_transfer(sender, receiver_node, network, fake_time, step=0.5, max_steps=6000)
+
+    assert sender.finished, "Sender should finish transfer despite slow acknowledgements"
+    assert (
+        receiver_node.receiver is not None and receiver_node.receiver.finished
+    ), "Receiver should finish transfer despite slow acknowledgements"
+    assert source_path.read_bytes() == payload, "Transferred payload should match original data"
+    assert (
+        sender.retry_timeout >= 8.0
+    ), f"Retry timeout should adapt to slow RTT, got {sender.retry_timeout}"
+
+
 def test_manager_handles_initial_request_in_payload():
     interface = DummyInterface()
     manager = FileTransManager(interface, auto_restart=True)


### PR DESCRIPTION
## Summary
- add adaptive retry timeout tracking to the sender to back off when acknowledgements are slow
- update slow acknowledgement handling test coverage to ensure the timeout grows appropriately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dae832f6e4832483b5e7cba54dd641