### PR TITLE
fix: route binary transfers over waypoint port

### DIFF
--- a/Receiver/receiver.py
+++ b/Receiver/receiver.py
@@ -46,7 +46,8 @@ CORE_PORTNUMS = {
     'TRACEROUTE_APP',
 }
 
-TRANSFER_PORT_NAME = 'TEXT_MESSAGE_APP'
+TRANSFER_PORT_NAME = 'WAYPOINT_APP'
+LEGACY_TRANSFER_PORT_NAMES = {TRANSFER_PORT_NAME, 'TEXT_MESSAGE_APP'}
 
 
 def main(interface):
@@ -100,7 +101,7 @@ def on_receive(packet, interface): # called when a packet arrives
     text = decoded.get('text') if portnum in CORE_PORTNUMS else None
     if portnum in CORE_PORTNUMS and text is not None:
         Text_Queue.append((interface.getShortName(), packet))
-    elif portnum == TRANSFER_PORT_NAME and 'payload' in decoded:
+    elif portnum in LEGACY_TRANSFER_PORT_NAMES and 'payload' in decoded:
         Queue.append((interface.getShortName(), packet))
 
 

--- a/Sender/sender.py
+++ b/Sender/sender.py
@@ -46,7 +46,8 @@ CORE_PORTNUMS = {
     'TRACEROUTE_APP',
 }
 
-TRANSFER_PORT_NAME = 'TEXT_MESSAGE_APP'
+TRANSFER_PORT_NAME = 'WAYPOINT_APP'
+LEGACY_TRANSFER_PORT_NAMES = {TRANSFER_PORT_NAME, 'TEXT_MESSAGE_APP'}
 
 
 def main(interface):
@@ -140,7 +141,7 @@ def on_receive(packet, interface): # called when a packet arrives
     )
     decoded = packet.get('decoded', {})
     portnum = decoded.get('portnum')
-    if portnum == TRANSFER_PORT_NAME and 'payload' in decoded:
+    if portnum in LEGACY_TRANSFER_PORT_NAMES and 'payload' in decoded:
         Queue.append((interface.getShortName(), packet))
     elif portnum in CORE_PORTNUMS and 'text' in decoded:
         Text_Queue.append((interface.getShortName(), packet))

--- a/file_classes.py
+++ b/file_classes.py
@@ -116,9 +116,11 @@ class ChunkProgressDisplay:
         sys.stdout.flush()
         self.closed = True
 
-# File transfer traffic now uses the same core port number as the initial
-# request message so radios treat the packets as standard application data.
-TRANSFER_PORTNUM = portnums_pb2.TEXT_MESSAGE_APP
+# File transfer traffic historically reused the text message port. Recent
+# Meshtastic firmware started strictly decoding that port as UTF-8 which breaks
+# our binary payloads.  Use the waypoint application port instead so the stack
+# will forward the bytes untouched.
+TRANSFER_PORTNUM = portnums_pb2.WAYPOINT_APP
 
 RECEIVER_STATUS_CHARS = {
     "waiting": ".",

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -217,7 +217,7 @@ def test_transfer_completes_on_open_channel(tmp_path):
     assert receiver_node.receiver is not None and receiver_node.receiver.finished
     assert source_path.read_bytes() == payload
     assert all(
-        portNum == portnums_pb2.TEXT_MESSAGE_APP for _dest, _data, portNum, _wantAck in sender_iface.sent_data
+        portNum == portnums_pb2.WAYPOINT_APP for _dest, _data, portNum, _wantAck in sender_iface.sent_data
     )
 
 

--- a/tests/test_receiver_routing.py
+++ b/tests/test_receiver_routing.py
@@ -52,7 +52,7 @@ def test_on_receive_routes_text_messages():
     _reset_queues()
     packet = {
         'decoded': {
-            'portnum': receiver.TRANSFER_PORT_NAME,
+            'portnum': 'TEXT_MESSAGE_APP',
             'text': 'hello world',
             'payload': bytearray(b'hello world'),
         },


### PR DESCRIPTION
## Summary
- send binary file transfer packets on the WAYPOINT_APP port to avoid UTF-8 decoding
- allow the sender and receiver clients to consume legacy TEXT_MESSAGE_APP packets while defaulting to the new port
- update tests to cover the new routing behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daeff7bb3c83248393fe87dc3b1f4d